### PR TITLE
Use KeyName type for KeyName parameter

### DIFF
--- a/template.json
+++ b/template.json
@@ -11,7 +11,7 @@
             "Description": "The subnets that the load balancer will cover",
         },
         "KeyName": {
-            "Type": "String",
+            "Type": "AWS::EC2::KeyPair::KeyName",
             "Description": "Name of an AWS keypair to use on instances"
         },
 


### PR DESCRIPTION
AWS a while back added this type to parameters. I think it will result in an earlier error if its set to something invalid, and if you create the stack via the aws console, it gives you a dropdown of existing keys rather than a free text field so it is harder to screw up.